### PR TITLE
Pre-emptively (and provisionally?) update code-utils for Istanbul

### DIFF
--- a/packages/code-utils/opcodes.ts
+++ b/packages/code-utils/opcodes.ts
@@ -58,6 +58,8 @@ const codes: opcodes = {
   0x43: "NUMBER",
   0x44: "DIFFICULTY",
   0x45: "GASLIMIT",
+  0x46: "CHAINID",
+  0x47: "SELFBALANCE",
 
   // 0x50 range - 'storage' and execution
   0x50: "POP",


### PR DESCRIPTION
This PR pre-emptively updates `@truffle/code-utils` for Istanbul by adding the `CHAINID` opcode at `0x46` and the `SELFBALANCE` opcode at `0x47`.  Hopefully this is indeed how Istanbul actually goes and we don't have to change this again later! :P