### PR TITLE
Internal improvement: Use object spreads for settings in compile packages

### DIFF
--- a/packages/compile-solidity/run.js
+++ b/packages/compile-solidity/run.js
@@ -152,14 +152,7 @@ function prepareCompilerInput({
     language,
     sources: prepareSources({ sources }),
     settings: {
-      evmVersion: settings.evmVersion,
-      optimizer: settings.optimizer,
-      remappings: settings.remappings,
-      debug: settings.debug,
-      metadata: settings.metadata,
-      libraries: settings.libraries,
-      viaIR: settings.viaIR,
-      modelChecker: settings.modelChecker,
+      ...settings,
       // Specify compilation targets. Each target uses defaultSelectors,
       // defaulting to single target `*` if targets are unspecified
       outputSelection: prepareOutputSelection({ targets })

--- a/packages/compile-vyper/vyper-json.js
+++ b/packages/compile-vyper/vyper-json.js
@@ -132,7 +132,7 @@ function prepareCompilerInput({
     sources: prepareSources({ sources }),
     interfaces: prepareInterfaces({ interfaces }),
     settings: {
-      evmVersion: settings.evmVersion,
+      ...settings,
       outputSelection
     },
     //older versions of vyper require outputSelection *outside* of settings.


### PR DESCRIPTION
Because we didn't use object spreads here, I had to keep updating this every time a new compiler setting was added.  Having to do that manually is a pain; better to just use an object spread.

Note that since we decided a while ago not to support Solidity's `stopAfter` option (at least for now), I set `stopAfter: undefined` just to be sure we'll ignore it if someone sets it anyway. :P  But I could remove that line if you don't think it should be there (maybe it's better to just allow it since it'll probably just cause errors anyway?).

Why didn't we use an object spread in the first place?  Well, old versions of Node didn't support it; and then, even once Node supported it, for a while Webpack didn't.  But that's all long gone now; we could have changed this a while ago, in truth, but, well, I hadn't bothered, and now seemed appropriate.