### PR TITLE
Add node_modules to init gitignore file

### DIFF
--- a/packages/core/lib/commands/init/initSource/.gitignore
+++ b/packages/core/lib/commands/init/initSource/.gitignore
@@ -1,1 +1,2 @@
 .env
+node_modules


### PR DESCRIPTION
## PR description

Resolves #3518.

Adds `node_modules` to the init script's **.gitignore** file.

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.
