### PR TITLE
Fix: `truffle unbox` use `spawnSync` to run the post-install hook

### DIFF
--- a/packages/box/lib/utils/unbox.ts
+++ b/packages/box/lib/utils/unbox.ts
@@ -4,7 +4,7 @@ import download from "download-git-repo";
 import axios from "axios";
 import vcsurl from "vcsurl";
 import { parse as parseURL } from "url";
-import { execSync } from "child_process";
+import { spawnSync } from "child_process";
 import inquirer from "inquirer";
 import type { Question } from "inquirer";
 import type { boxConfig, unboxOptions } from "typings";
@@ -148,7 +148,12 @@ function installBoxDependencies({ hooks }: boxConfig, destination: string) {
   const postUnpack = hooks["post-unpack"];
 
   if (postUnpack.length === 0) return;
-  execSync(postUnpack, { cwd: destination, stdio: "ignore" });
+
+  spawnSync(postUnpack, {
+    cwd: destination,
+    shell: true,
+    stdio: ["ignore", process.stdout, process.stderr]
+  });
 }
 
 export = {

--- a/packages/box/lib/utils/unbox.ts
+++ b/packages/box/lib/utils/unbox.ts
@@ -148,7 +148,7 @@ function installBoxDependencies({ hooks }: boxConfig, destination: string) {
   const postUnpack = hooks["post-unpack"];
 
   if (postUnpack.length === 0) return;
-  execSync(postUnpack, { cwd: destination });
+  execSync(postUnpack, { cwd: destination, stdio: "ignore" });
 }
 
 export = {


### PR DESCRIPTION
## PR description

This replace `execSync` in favor of `spawnSync`  to run the post-install hook avoiding a `ENOBUFS` error due to Yarn 3 filling the 200 ko Buffer limit of the spawned process.

## Testing instructions

- Run the `truffle unbox metamask/snap-box` command
- Observe that the command succeeds.

## Demo

With a `npm` box:

https://user-images.githubusercontent.com/13910212/206447417-0debb5e4-b2a8-450a-afac-9c1e93db96f8.mp4

With a `yarn` box


https://user-images.githubusercontent.com/13910212/206448780-06e49e1a-58ee-4ab1-976e-4714140b8647.mp4

