### PR TITLE
ci(scripts): pin geth to v1.11.6

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -6,7 +6,7 @@
 # - https://hub.docker.com/r/ethereum/client-go
 # - https://github.com/ethereum/go-ethereum/releases
 # GETH_VERSION="stable"
-GETH_VERSION="v1.10.26"
+GETH_VERSION="v1.11.6"
 
 # Exit script as soon as a command fails.
 set -o errexit

--- a/scripts/geth.sh
+++ b/scripts/geth.sh
@@ -6,7 +6,7 @@
 # - https://hub.docker.com/r/ethereum/client-go
 # - https://github.com/ethereum/go-ethereum/releases
 # GETH_VERSION="stable"
-GETH_VERSION="v1.10.26"
+GETH_VERSION="v1.11.6"
 
 docker pull "ethereum/client-go:$GETH_VERSION"
 


### PR DESCRIPTION
## PR description

Bumps geth from v1.10 to v1.11.6.

## Testing instructions

Watch CI pass

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.

## Breaking changes and new features

- [x] I have added any needed `breaking-change` and `new-feature` labels for the appropriate packages.
