### PR TITLE
ci: unpin nodejs 20.5

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest]
         # TODO: unpin to 20.x once 20.7 has ben released
-        node-version: [16.x, 18.x, 20.5]
+        node-version: [16.x, 18.x, 20.x]
         env: [GETH=true, PACKAGES=true, INTEGRATION=true]
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
## PR description

This reverts the pinning of Node.js 20.5 originally done in #6186.

The upstream issue has now been resolved.

## Testing instructions

CI should pass.

## Documentation

- [x] I thought about documentation and added the `doc-change-required` label to this PR if documentation updates are required.

## Breaking changes and new features

- [x] I have added any needed `breaking-change` and `new-feature` labels for the appropriate packages.
